### PR TITLE
Deep contents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,6 @@ ToastStunt is the server that runs [Miriani](https://www.toastsoft.net) and [Cha
     - locations (recursive location function)
     - clear_ancestor_cache (clears the ancestor cache manually)
     - chr (return extended ASCII characters; characters that can corrupt your database are considered invalid)
-    - levenshtein_distance (calculate the Levenshtein distance between two strings)
     - deep_contents (get all nested contents of an object. Provide as a second argument a parent if you want only descendants of that parent returned)
 
 - Miscellaneous changes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ ToastStunt is the server that runs [Miriani](https://www.toastsoft.net) and [Cha
     - clear_ancestor_cache (clears the ancestor cache manually)
     - chr (return extended ASCII characters; characters that can corrupt your database are considered invalid)
     - levenshtein_distance (calculate the Levenshtein distance between two strings)
+    - deep_contents (get all nested contents of an object. Provide as a second argument a parent if you want only descendants of that parent returned)
 
 - Miscellaneous changes:
     - Numeric IP addresses in connection_name

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ ToastStunt is the server that runs [Miriani](https://www.toastsoft.net) and [Cha
     - locations (recursive location function)
     - clear_ancestor_cache (clears the ancestor cache manually)
     - chr (return extended ASCII characters; characters that can corrupt your database are considered invalid)
+    - levenshtein_distance (calculate the Levenshtein distance between two strings)
 
 - Miscellaneous changes:
     - Numeric IP addresses in connection_name

--- a/extensions.cc
+++ b/extensions.cc
@@ -1,3 +1,5 @@
+#include <algorithm> //min
+#include <memory> //unique_ptr
 #include <math.h>           // sqrt, atan, round, etc
 #include "functions.h"      // register builtins
 #include "log.h"            // oklog()
@@ -16,6 +18,8 @@
 #ifdef __MACH__
 #include <mach/clock.h>     // Millisecond time for OS X
 #endif
+
+using namespace std;
 
 /**
 * On FreeBSD, CLOCK_MONOTONIC_RAW is simply CLOCK_MONOTONIC

--- a/extensions.cc
+++ b/extensions.cc
@@ -1,5 +1,3 @@
-#include <algorithm> //min
-#include <memory> //unique_ptr
 #include <set>
 #include <math.h>           // sqrt, atan, round, etc
 #include "functions.h"      // register builtins
@@ -568,37 +566,6 @@ bf_remove_ansi(Var arglist, Byte next, void *vdata, Objid progr)
 }
 //==============================================================
 
-static int levenshtein(const char *const s1, const char *const s2, const int s1len, const int s2len)
-{
-    if (s1 == nullptr || s2 == nullptr)
-        return 0;
-    if (s1len == 0 && s2len == 0)
-        return 0;
-
-    unique_ptr<int[]> column(new int[s1len+1]);
-    for (int y = 1; y <= s1len; y++)
-        column[y] = y;
-    for (int x = 1; x <= s2len; x++)
-        {
-            column[0] = x;
-            for (int y = 1, lastdiag = x-1; y <= s1len; y++)
-                {
-                    int olddiag = column[y];
-                    column[y] = min(min(column[y] + 1, column[y-1] + 1), lastdiag + (s1[y-1] == s2[x-1] ? 0 : 1));
-                    lastdiag = olddiag;
-                }
-        }
-    return(column[s1len]);
-}
-
-static package
-bf_levenshtein(Var arglist, Byte next, void *vdata, Objid progr)
-{
-    const int distance = levenshtein(arglist.v.list[1].v.str, arglist.v.list[2].v.str, memo_strlen(arglist.v.list[1].v.str), memo_strlen(arglist.v.list[2].v.str));
-    free_var(arglist);
-    return make_var_pack(Var::new_int(distance));
-}
-
 static void do_deep_contents(set<Objid> &objids, Var &branch, Var& parent, bool perform_isa=false)
 {
     if (branch.type != TYPE_OBJ)
@@ -698,7 +665,6 @@ register_extensions()
     register_function("occupants", 1, 3, bf_occupants, TYPE_LIST, TYPE_OBJ, TYPE_INT);
     register_function("locations", 1, 1, bf_locations, TYPE_OBJ);
     register_function("chr", 1, 1, bf_chr, TYPE_INT);
-    register_function("levenshtein_distance", 2, 2, bf_levenshtein, TYPE_STR, TYPE_STR);
     register_function("deep_contents", 1, 2, bf_deep_contents, TYPE_OBJ, TYPE_OBJ);
     // ======== ANSI ===========
     register_function("parse_ansi", 1, 1, bf_parse_ansi, TYPE_STR);

--- a/extensions.cc
+++ b/extensions.cc
@@ -562,6 +562,37 @@ bf_remove_ansi(Var arglist, Byte next, void *vdata, Objid progr)
 }
 //==============================================================
 
+static int levenshtein(const char *const s1, const char *const s2, const int s1len, const int s2len)
+{
+    if (s1 == nullptr || s2 == nullptr)
+        return 0;
+    if (s1len == 0 && s2len == 0)
+        return 0;
+
+    unique_ptr<int[]> column(new int[s1len+1]);
+    for (int y = 1; y <= s1len; y++)
+        column[y] = y;
+    for (int x = 1; x <= s2len; x++)
+        {
+            column[0] = x;
+            for (int y = 1, lastdiag = x-1; y <= s1len; y++)
+                {
+                    int olddiag = column[y];
+                    column[y] = min(min(column[y] + 1, column[y-1] + 1), lastdiag + (s1[y-1] == s2[x-1] ? 0 : 1));
+                    lastdiag = olddiag;
+                }
+        }
+    return(column[s1len]);
+}
+
+static package
+bf_levenshtein(Var arglist, Byte next, void *vdata, Objid progr)
+{
+    const int distance = levenshtein(arglist.v.list[1].v.str, arglist.v.list[2].v.str, memo_strlen(arglist.v.list[1].v.str), memo_strlen(arglist.v.list[2].v.str));
+    free_var(arglist);
+    return make_var_pack(Var::new_int(distance));
+}
+
     void
 register_extensions()
 {
@@ -578,6 +609,7 @@ register_extensions()
     register_function("occupants", 1, 3, bf_occupants, TYPE_LIST, TYPE_OBJ, TYPE_INT);
     register_function("locations", 1, 1, bf_locations, TYPE_OBJ);
     register_function("chr", 1, 1, bf_chr, TYPE_INT);
+    register_function("levenshtein_distance", 2, 2, bf_levenshtein, TYPE_STR, TYPE_STR);
     // ======== ANSI ===========
     register_function("parse_ansi", 1, 1, bf_parse_ansi, TYPE_STR);
     register_function("remove_ansi", 1, 1, bf_remove_ansi, TYPE_STR);

--- a/extensions.cc
+++ b/extensions.cc
@@ -606,7 +606,7 @@ static void do_deep_contents(set<Objid> &objids, Var &branch, Var& parent, bool 
 * will retrieve all players nested in that object.
 * A few notes:
 * We use std::set to make sure that we are performing set operations.
-* This probably isn't needed; if you've got an object appearing in two different contents chances are shit's fucked up, but better safe than sorry.
+* This probably isn't needed; if you've got an object appearing in two different contents chances are something went wrong, but better safe than sorry.
 * This set also serves the duel purpose of constructing a set without having to call setadd multiple times on a MOO list.
 * This is much quicker because we can keep adding to this and then get the final count of elements as the size of the list, which requires less reallocation of the list itself.
 */


### PR DESCRIPTION
This function retrieves recursively the contents of all objects and merges them into one set.
Pass as a second argument an object if you want an isa to be used.
For example, `deep_contents(#1234, $player)`
will retrieve all players nested in that object.
A few notes:
We use std::set to make sure that we are performing set operations.
 This probably isn't needed; if you've got an object appearing in two different contents chances are something went wrong, but better safe than sorry.
 This set also serves the duel purpose of constructing an in-moo list without having to call setadd multiple times on a MOO list.
 This is much quicker because we can keep adding to the set and then get the final count of elements as the size of the list, which requires less reallocation
of the list itself.
