### PR TITLE
recycle_waifs fix

### DIFF
--- a/server.cc
+++ b/server.cc
@@ -23,6 +23,7 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <vector>
 
 #include "my-types.h"		/* must be first on some systems */
 #include "my-signal.h"
@@ -569,16 +570,20 @@ recycle_waifs(void)
         strcpy(waif_recycle_verb + 1, "recycle");
     }
 
-    for (auto& x : recycled_waifs) {
+    std::vector<Waif*> removals;
+    for (auto &x: recycled_waifs) {
         if (recycled_waifs[x.first] == false) {
             run_server_task(-1, Var::new_waif(x.first), waif_recycle_verb, new_list(0), "", 0);
             recycled_waifs[x.first] = true;
             /* Flag it as recycled. Now we just wait for the refcount to hit zero so we can free it. */
         }
         if (refcount(x.first) == 0) {
-            free_waif(x.first);
-            recycled_waifs.erase(x.first);
+            removals.push_back(x.first);
         }
+      }  
+      for (auto x:removals) {
+        free_waif(x);
+        recycled_waifs.erase(x);
     }
 }
 

--- a/waif.cc
+++ b/waif.cc
@@ -33,11 +33,11 @@
 #include "db.h" 		// valid
 #include "log.h"        // errlog
 #include "map.h"
-#include <map>
+#include <unordered_map>
 
 static unsigned long waif_count = 0;
-static std::map<Objid, unsigned int> waif_class_count;
-std::map<Waif *, bool> recycled_waifs;
+static std::unordered_map<Objid, unsigned int> waif_class_count;
+std::unordered_map<Waif *, bool> recycled_waifs;
 
 #define PROP_MAPPED(Mmap, Mbit)	((Mmap)[(Mbit) / 32] & (1 << ((Mbit) % 32)))
 #define MAP_PROP(Mmap, Mbit) (Mmap)[(Mbit) / 32] |= 1 << ((Mbit) % 32)

--- a/waif.h
+++ b/waif.h
@@ -22,12 +22,12 @@
 #ifndef WAIF_h
 #define WAIF_h
 
-#include <map>
+#include <unordered_map>
 
 #define WAIF_PROP_PREFIX	':'
 #define WAIF_VERB_PREFIX	':'
 
-extern std::map<Waif *, bool> recycled_waifs;
+extern std::unordered_map<Waif *, bool> recycled_waifs;
 
 #ifdef WAIF_DICT
 #define WAIF_INDEX_VERB ":_index"


### PR DESCRIPTION
This PR contains logic fixes to `recycle_waifs`
reproduction steps:
1. Load stock Lambdacore.
2. @create #1 called "generic waif",waif
3. @corify waif as waif
4. @verb waif:new tnt
5. @program waif:new
6. Paste the following code:
set_task_perms(caller_perms());
w = new_waif();
w:initialize();
return w;
7. Once the verb saves, eval $waif:new();
Expected: E_VRBNF; got panic.
The issue is that we were previously calling recycled_waifs:erase, which was invalidating the current iterator.
1. Create a vector which stores a list of all waifs to be recycled. After we mark them for recycle, iterate through that vector and free/remove them from the map.
2. I also took the opportunity to update the map on both recycled_waifs and waif_class_count to be an unordered_map. These are true hashes (and pointers can be hashed), so the amount of indexing and setting done will be sped up by a decent amount.
reproduction steps:
1. Load stock Lambdacore.
2. @create #1 called "generic waif",waif
3. @corify waif as waif
4. @verb waif:new tnt
5. @program waif:new
6. Paste the following code:
set_task_perms(caller_perms());
w = new_waif();
w:initialize();
return w;
7. Once the verb saves, eval $waif:new();
Expected: E_VRBNF; got panic.
The issue is that we were previously calling recycled_waifs:erase, which was invalidating the current iterator.
1. Create a vector which stores a list of all waifs to be recycled. After we mark them for recycle, iterate through that vector and free/remove them from the map.
2. I also took the opportunity to update the map on both recycled_waifs and waif_class_count to be an unordered_map. These are true hashes (and pointers can be hashed), so the amount of indexing and setting done will be sped up by a decent amount.