### PR TITLE
Fixed free() crash in argon2()

### DIFF
--- a/extension-argon2.cc
+++ b/extension-argon2.cc
@@ -52,7 +52,7 @@ bf_argon2(Var arglist, Byte next, void *vdata, Objid progr)
     if (result != ARGON2_OK) {
         free_var(arglist);
         free(out);
-        free(encoded);
+        myfree(encoded, M_STRING);
         return make_raise_pack(E_INVIND, argon2_error_message(result), var_ref(zero));
     }
 


### PR DESCRIPTION
This PR fixes a serious crash error that results in the corruption of the checkpoint database when argon2() is called with any parameters. Currently, argon2() allocates memory for the encoded argon2 data with mymalloc(), but frees it with free() and not myfree(). Unfortunately, as a result of the free() call, the checkpoint DB is corrupted and will fail to load. Before testing, back up your CP DB.