### PR TITLE
code cleanups on sqlite

### DIFF
--- a/extension-sqlite.cc
+++ b/extension-sqlite.cc
@@ -1,5 +1,13 @@
+#include <unordered_map>
+
 #include "extension-sqlite.h"
 #include "extension-background.h"
+
+// Map of open connections
+static std::unordered_map <int, sqlite_conn> sqlite_connections;
+// Next database handle. This will get reset to 1 when all connections get closed.
+static int next_sqlite_handle = 1;
+
 
 /* Open an SQLite database.
  * Args: STR <path to database>, [INT options] */

--- a/extension-sqlite.h
+++ b/extension-sqlite.h
@@ -3,7 +3,6 @@
 
 #include <sqlite3.h>
 #include <stdbool.h>
-#include <map>
 
 #include "functions.h"
 #include "numbers.h"
@@ -39,11 +38,6 @@ typedef struct sqlite_result
     sqlite_conn *connection;
     Var last_result;
 } sqlite_result;
-
-// Map of open connections
-static std::map <int, sqlite_conn> sqlite_connections;
-// Next database handle. This will get reset to 1 when all connections get closed.
-static int next_sqlite_handle = 1;
 
 // Forward declarations
 extern const char *file_resolve_path(const char *);             // from fileio.cc


### PR DESCRIPTION
There are no reproduction steps or bugs associated with this PR; this is a simple cleanup of some sqlite code.

Move the variables from the header file into the c file so that they will be part of the correct translation unit.
Update the std::map to be std::unordered_map; this is a true hash supported by c++11 and can speed up lookups of sqlite handles from O(N) to O(1).