### PR TITLE
fixed a memory problem in db_object_isa

### DIFF
--- a/db_objects.cc
+++ b/db_objects.cc
@@ -1183,7 +1183,7 @@ db_object_isa(Var object, Var parent)
 
 	ancestors = listconcat(ancestors, enlist_var(var_ref(t->parents)));
     }
-
+    free_var(ancestors);
     return 0;
 }
 


### PR DESCRIPTION
Added a free_var(ancestors) into db_object_isa above where it returns 0, as not having this seemed to cause a memory crash at random.…an cause memory bugs that cause the server to crash.