### PR TITLE
changed around match_object slightly

### DIFF
--- a/match.cc
+++ b/match.cc
@@ -115,18 +115,20 @@ match_contents(Objid player, const char *name)
 Objid
 match_object(Objid player, const char *name)
 {
-    if (name[0] == '\0')
-	return NOTHING;
-    if (name[0] == '#') {
-	char *p;
-	Objid r = strtol(name + 1, &p, 10);
+    Var matched_object;
+    Var match_object_args;
 
-	if (*p != '\0' || !valid(r))
-	    return FAILED_MATCH;
-	return r;
-    }
-    if (!valid(player))
-	return FAILED_MATCH;
+    match_object_args = new_list(1);
+    match_object_args.v.list[1].type = TYPE_STR;
+    match_object_args.v.list[1].v.str = str_dup(name);
+
+    run_server_task(player, Var::new_obj(SYSTEM_OBJECT), "match_object",
+                    match_object_args, name, &matched_object);
+    if (matched_object.type == TYPE_OBJ)
+        return matched_object.v.obj;
+	else
+		free_var(matched_object);	// OBJ doesn't need to free, but others might
+    
     if (!strcasecmp(name, "me"))
 	return player;
     if (!strcasecmp(name, "here"))


### PR DESCRIPTION
Patched in code that allows match_object to call #0:match_object, allowing for fun in mud matching such as first.object, or 1.object, ETC.