### PR TITLE
Remove the artificial limit on builtin functions.

### DIFF
--- a/src/functions.cc
+++ b/src/functions.cc
@@ -16,6 +16,8 @@
  *****************************************************************************/
 
 #include <stdarg.h>
+#include <vector>
+#include <functional>
 
 #include "bf_register.h"
 #include "config.h"
@@ -31,7 +33,13 @@
 #include "unparse.h"
 #include "utils.h"
 
-/*****************************************************************************
+using namespace std;
+typedef function<void()> registry;
+
+void
+register_bi_functions()
+{
+	/*****************************************************************************
  * This is the table of procedures that register MOO built-in functions.  To
  * add new built-in functions to the server, add to the list below the name of
  * a C function that will register your new MOO built-ins; your C function will
@@ -39,10 +47,7 @@
  * declaration of that C function to `bf_register.h' and add the necessary .c
  * files to the `CSRCS' line in the Makefile.
  ****************************************************************************/
-
-typedef void (*registry) ();
-
-static registry bi_function_registries[] =
+	const vector<registry> registry_callbacks =
 {
 #ifdef ENABLE_GC
     register_gc,
@@ -76,16 +81,11 @@ static registry bi_function_registries[] =
     register_spellcheck,
     register_curl
 };
-
-void
-register_bi_functions()
+	for (const auto& callback: registry_callbacks)
 {
-    int loop, num_registries =
-    sizeof(bi_function_registries) / sizeof(bi_function_registries[0]);
-
-    for (loop = 0; loop < num_registries; loop++)
-	(void) (*(bi_function_registries[loop])) ();
+	callback();
 }
+    }
 
 /*** register ***/
 
@@ -102,10 +102,9 @@ struct bft_entry {
     int _protected;
 };
 
-static struct bft_entry bf_table[MAX_FUNC];
-static unsigned top_bf_table = 0;
+static vector<bft_entry> bf_table;
 
-static unsigned
+static void
 register_common(const char *name, int minargs, int maxargs, bf_type func,
 		bf_read_type read, bf_write_type write, va_list args)
 {
@@ -116,68 +115,60 @@ register_common(const char *name, int minargs, int maxargs, bf_type func,
     if (!s)
 	s = new_stream(30);
 
-    if (top_bf_table == MAX_FUNC) {
-	errlog("too many functions.  %s cannot be registered.\n", name);
-	return 0;
-    }
-    bf_table[top_bf_table].name = str_dup(name);
+	bft_entry entry;
+entry.name = str_dup(name);
     stream_printf(s, "protect_%s", name);
-    bf_table[top_bf_table].protect_str = str_dup(reset_stream(s));
+    entry.protect_str = str_dup(reset_stream(s));
     stream_printf(s, "bf_%s", name);
-    bf_table[top_bf_table].verb_str = str_dup(reset_stream(s));
-    bf_table[top_bf_table].minargs = minargs;
-    bf_table[top_bf_table].maxargs = maxargs;
-    bf_table[top_bf_table].func = func;
-    bf_table[top_bf_table].read = read;
-    bf_table[top_bf_table].write = write;
-    bf_table[top_bf_table]._protected = 0;
+entry.verb_str = str_dup(reset_stream(s));
+    entry.minargs = minargs;
+    entry.maxargs = maxargs;
+    entry.func = func;
+    entry.read = read;
+    entry.write = write;
+    entry._protected = 0;
 
     if (num_arg_types > 0)
-	bf_table[top_bf_table].prototype =
+	entry.prototype =
 	    (var_type *)mymalloc(num_arg_types * sizeof(var_type), M_PROTOTYPE);
     else
-	bf_table[top_bf_table].prototype = nullptr;
+	entry.prototype = nullptr;
     for (va_index = 0; va_index < num_arg_types; va_index++)
-	bf_table[top_bf_table].prototype[va_index] = (var_type)va_arg(args, int);
-
-    return top_bf_table++;
-}
-
-unsigned
+	entry.prototype[va_index] = (var_type)va_arg(args, int);
+bf_table.push_back(entry);
+    }
+	
+void 
 register_function(const char *name, int minargs, int maxargs,
 		  bf_type func,...)
 {
     va_list args;
-    unsigned ans;
-
+    
     va_start(args, func);
-    ans = register_common(name, minargs, maxargs, func, nullptr, nullptr, args);
+    register_common(name, minargs, maxargs, func, nullptr, nullptr, args);
     va_end(args);
-    return ans;
 }
 
-unsigned
+void
 register_function_with_read_write(const char *name, int minargs, int maxargs,
 				  bf_type func, bf_read_type read,
 				  bf_write_type write,...)
 {
     va_list args;
-    unsigned ans;
+
 
     va_start(args, write);
-    ans = register_common(name, minargs, maxargs, func, read, write, args);
+    register_common(name, minargs, maxargs, func, read, write, args);
     va_end(args);
-    return ans;
-}
+    }
 
 /*** looking up functions -- by name or num ***/
 
 static const char *func_not_found_msg = "no such function";
-
 const char *
 name_func_by_num(unsigned n)
 {				/* used by unparse only */
-    if (n >= top_bf_table)
+    if (n >= bf_table.size()-1)
 	return func_not_found_msg;
     else
 	return bf_table[n].name;
@@ -186,9 +177,9 @@ name_func_by_num(unsigned n)
 unsigned
 number_func_by_name(const char *name)
 {				/* used by parser only */
-    unsigned i;
-
-    for (i = 0; i < top_bf_table; i++)
+    
+	const auto functionCount = bf_table.size();
+    for (size_t i = 0; i < functionCount; ++i)
 	if (!strcasecmp(name, bf_table[i].name))
 	    return i;
 
@@ -203,14 +194,14 @@ call_bi_func(unsigned n, Var arglist, Byte func_pc,
      /* requires arglist.type == TYPE_LIST
         call_bi_func will free arglist */
 {
-    struct bft_entry *f;
-
-    if (n >= top_bf_table) {
+	const auto functionCount = bf_table.size();
+    
+    if (n >= functionCount) {
 	errlog("CALL_BI_FUNC: Unknown function number: %d\n", n);
 	free_var(arglist);
 	return no_var_pack();
     }
-    f = bf_table + n;
+    const auto f = bf_table[n];
 
     if (func_pc == 1) {		/* check arg types and count *ONLY* for first entry */
 	int k, max;
@@ -219,9 +210,9 @@ call_bi_func(unsigned n, Var arglist, Byte func_pc,
 	/*
 	 * Check permissions, if protected
 	 */
-	if ((!caller().is_obj() || caller().v.obj != SYSTEM_OBJECT) && f->_protected) {
+	if ((!caller().is_obj() || caller().v.obj != SYSTEM_OBJECT) && f._protected) {
 	    /* Try calling #0:bf_FUNCNAME(@ARGS) instead */
-	    enum error e = call_verb2(SYSTEM_OBJECT, f->verb_str, Var::new_obj(SYSTEM_OBJECT), arglist, 0, get_thread_mode());
+	    enum error e = call_verb2(SYSTEM_OBJECT, f.verb_str, Var::new_obj(SYSTEM_OBJECT), arglist, 0, get_thread_mode());
 
 	    if (e == E_NONE)
 		return tail_call_pack();
@@ -235,18 +226,18 @@ call_bi_func(unsigned n, Var arglist, Byte func_pc,
 	 * Check argument count
 	 * (Can't always check in the compiler, because of @)
 	 */
-	if (args[0].v.num < f->minargs
-	    || (f->maxargs != -1 && args[0].v.num > f->maxargs)) {
+	if (args[0].v.num < f.minargs
+	    || (f.maxargs != -1 && args[0].v.num > f.maxargs)) {
 	    free_var(arglist);
 	    return make_error_pack(E_ARGS);
 	}
 	/*
 	 * Check argument types
 	 */
-	max = (f->maxargs == -1) ? f->minargs : args[0].v.num;
+	max = (f.maxargs == -1) ? f.minargs : args[0].v.num;
 
 	for (k = 0; k < max; k++) {
-	    var_type proto = f->prototype[k];
+	    var_type proto = f.prototype[k];
 	    var_type arg = args[k + 1].type;
 
 	    if (!(proto == TYPE_ANY
@@ -266,14 +257,15 @@ call_bi_func(unsigned n, Var arglist, Byte func_pc,
     /*
      * do the function
      */
-    return (*(f->func)) (arglist, func_pc, vdata, progr);
+    return (*(f.func)) (arglist, func_pc, vdata, progr);
     /* f->func is responsible for freeing/using up arglist. */
 }
 
 void
 write_bi_func_data(void *vdata, Byte f_id)
 {
-    if (f_id >= top_bf_table)
+	const auto functionCount = bf_table.size();
+    if (f_id >= functionCount)
 	errlog("WRITE_BI_FUNC_DATA: Unknown function number: %d\n", f_id);
     else if (bf_table[f_id].write)
 	(*(bf_table[f_id].write)) (vdata);
@@ -291,8 +283,8 @@ int
 read_bi_func_data(Byte f_id, void **bi_func_state, Byte * bi_func_pc)
 {
     pc_for_bi_func_data_being_read = bi_func_pc;
-
-    if (f_id >= top_bf_table) {
+const auto functionCount = bf_table.size();
+    if (f_id >= functionCount) {
 	errlog("READ_BI_FUNC_DATA: Unknown function number: %d\n", f_id);
 	*bi_func_state = nullptr;
 	return 0;
@@ -453,18 +445,18 @@ static package
 bf_function_info(Var arglist, Byte next, void *vdata, Objid progr)
 {
     Var r;
-    unsigned int i;
 
-    if (arglist.v.list[0].v.num == 1) {
-	i = number_func_by_name(arglist.v.list[1].v.str);
+        if (arglist.v.list[0].v.num == 1) {
+	const auto i = number_func_by_name(arglist.v.list[1].v.str);
 	if (i == FUNC_NOT_FOUND) {
 	    free_var(arglist);
 	    return make_error_pack(E_INVARG);
 	}
 	r = function_description(i);
     } else {
-	r = new_list(top_bf_table);
-	for (i = 0; i < top_bf_table; i++)
+		const auto functionCount = bf_table.size();
+	r = new_list(functionCount);
+	for (size_t i = 0; i < functionCount; i++)
 	    r.v.list[i + 1] = function_description(i);
     }
 
@@ -475,13 +467,12 @@ bf_function_info(Var arglist, Byte next, void *vdata, Objid progr)
 static void
 load_server_protect_function_flags(void)
 {
-    unsigned int i;
-
-    for (i = 0; i < top_bf_table; i++) {
+    const auto functionCount = bf_table.size();
+    for (size_t i = 0; i < functionCount; i++) {
 	bf_table[i]._protected
 	    = server_flag_option(bf_table[i].protect_str, 0);
     }
-    oklog("Loaded protect cache for %d builtin functions\n", i);
+    oklog("Loaded protect cache for %d builtin functions\n", functionCount);
 }
 
 Num _server_int_option_cache[SVO__CACHE_SIZE];

--- a/src/include/functions.h
+++ b/src/include/functions.h
@@ -74,18 +74,13 @@ typedef package(*bf_type) (Var, Byte, void *, Objid);
 typedef void (*bf_write_type) (void *vdata);
 typedef void *(*bf_read_type) (void);
 
-#define MAX_FUNC         256
-#define FUNC_NOT_FOUND   MAX_FUNC
-/* valid function numbers are 0 - 255, or a total of 256 of them.
-   function number 256 is reserved for func_not_found signal.
-   hence valid function numbers will fit in one byte but the 
-   func_not_found signal will not */
-
+#define FUNC_NOT_FOUND   -1
+   
 extern const char *name_func_by_num(unsigned);
 extern unsigned number_func_by_name(const char *);
 
-extern unsigned register_function(const char *, int, int, bf_type,...);
-extern unsigned register_function_with_read_write(const char *, int, int,
+extern void register_function(const char *, int, int, bf_type,...);
+extern void register_function_with_read_write(const char *, int, int,
 						  bf_type, bf_read_type,
 						  bf_write_type,...);
 


### PR DESCRIPTION
Updated functions to use a vector to store their callbacks. Moved the registration calls into the function that calls them. This creates a path forward for converting function calls from O(N) to O(1)... Just as soon as I figure out why that's crashing.