### PR TITLE
Function bytefix

### DIFF
--- a/src/code_gen.cc
+++ b/src/code_gen.cc
@@ -188,6 +188,13 @@ emit_byte(Byte b, State * state)
 }
 
 static void
+emit_function_id(unsigned id, state* state)
+{
+    emit_byte(static_cast<Byte>((id >> 8) & 0x000000ff), state);
+    emit_byte(static_cast<Byte>(id&0x000000ff), state);
+}
+
+static void
 emit_extended_byte(Byte b, State * state)
 {
     emit_byte(OP_EXTENDED, state);
@@ -809,7 +816,7 @@ generate_expr(Expr * expr, State * state)
         case EXPR_CALL:
             generate_arg_list(expr->e.call.args, state);
             emit_byte(OP_BI_FUNC_CALL, state);
-            emit_byte(expr->e.call.func, state);
+            emit_function_id(expr->e.call.func, state);
             break;
         case EXPR_VERB:
             generate_expr(expr->e.verb.obj, state);

--- a/src/decompile.cc
+++ b/src/decompile.cc
@@ -388,7 +388,7 @@ finish_binary:
                 e = alloc_expr(EXPR_CALL);
                 e->e.call.args = a->e.list;
                 dealloc_node(a);
-                e->e.call.func = READ_BYTES(1);
+                e->e.call.func = READ_BYTES(2);
                 push_expr((Expr *)HOT_OP1(a, e));
             }
             break;

--- a/src/disassemble.cc
+++ b/src/disassemble.cc
@@ -37,7 +37,7 @@ struct mapping {
     const char *name;
 };
 
-struct mapping mappings[] =
+const struct mapping mappings[] =
 {
     {OP_IF, "IF"},
     {OP_WHILE, "WHILE"},
@@ -397,7 +397,7 @@ disassemble(Program * prog, Printer p, void *data)
                     }
                     break;
                     case OP_BI_FUNC_CALL:
-                        stream_printf(insn, " %s", name_func_by_num(ADD_BYTES(1)));
+                        stream_printf(insn, " %s", name_func_by_num(ADD_BYTES(2)));
                     default:
                         break;
                 }

--- a/src/execute.cc
+++ b/src/execute.cc
@@ -2151,7 +2151,7 @@ else if (obj.type == TYPE_##t1) {           \
                 unsigned func_id;
                 Var args;
 
-                func_id = READ_BYTES(bv, 1);    /* 1 == numbytes of func_id */
+                func_id = READ_BYTES(bv, 2);    /* 1 == numbytes of func_id */
                 args = POP();   /* should be list */
                 if (args.type != TYPE_LIST) {
                     free_var(args);

--- a/src/execute.cc
+++ b/src/execute.cc
@@ -3903,7 +3903,7 @@ check_pc_validity(Program * prog, int which_vector, unsigned pc)
      */
     return (pc < bc->size
             && (bc->vector[pc - 1] == OP_CALL_VERB
-                || bc->vector[pc - 2] == OP_BI_FUNC_CALL));
+                || bc->vector[pc - 3] == OP_BI_FUNC_CALL));
 }
 
 int


### PR DESCRIPTION
This PR fixes the issue where anything over 255 functions will cause errors by calling the wrong functions.
The problem: any function number over 255 will cycle back to 0, thus calling the wrong builtin function. There is no warning.
In much of current toaststunt (Lambda) code, function IDS are stored as 2-byte integers with exception of the bytecode which is the function call, proceeded by the function ID.
This fix changes this, so that the function call can be proceeded by a two-byte function ID.
The problem with this fix which I could not resolve is that of queued tasks.
If a DB is dumped with queued tasks, the PC is stored along with the code for that specific task at the point when it was started.
The server will then parse and recompile the current program, and substitute the bytecode into the vm for that task. The PC will then point to the proper place.
Given that we've just updated the function calls, this means that the PC will be off by however many function calls exist -before- the PC. I could not find a clean or safe way to adjust this pC without crashing, so this PR should be held until we can find a way to do this, or until we tell everyone they must kill tasks and then reload the db before respawning. The latter solution is far from my favorite.
test steps:
Load any server with more than 255 builtins.
Write a test verb and call builtin 256 and 257 in your list. compile the verb, and @list it.
If the builtins list properly, that means that the fix works; previously simply compiling the verb would translate the function calls to whichever in the list was at the value that the single byte wrapped around to.
