### PR TITLE
Update function lookups.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 option(ONLY_32_BITS "Use 32-bit integers instead of 64-bit." OFF)
 
 # Compiler Flags
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 99)
 
 # These flags are shared by the RELEASE and WARN build types.

--- a/src/execute.cc
+++ b/src/execute.cc
@@ -16,6 +16,7 @@
  *****************************************************************************/
 
 #include <chrono>
+#include <optional>
 #include <string.h>
 #include <stdarg.h>
 
@@ -47,6 +48,8 @@
 #include "version.h"
 #include "background.h"
 #include "unparse.h"
+
+using namespace std;
 
 /* the following globals are the guts of the virtual machine: */
 static activation *activ_stack = nullptr;
@@ -3036,9 +3039,9 @@ run_interpreter(char raise, enum error e,
     total_cputime.type = TYPE_FLOAT;
 
     interpreter_is_running = 1;
-    std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
+    chrono::high_resolution_clock::time_point start = chrono::high_resolution_clock::now();
     ret = run(raise, e, result);
-    std::chrono::duration<double> elapsed = std::chrono::high_resolution_clock::now() - start;
+    chrono::duration<double> elapsed = chrono::high_resolution_clock::now() - start;
     total_cputime.v.fnum = elapsed.count();
     interpreter_is_running = 0;
 
@@ -3354,12 +3357,13 @@ bf_call_function(Var arglist, Byte next, void *vdata, Objid progr)
     if (next == 1) {        /* first call */
         const char *fname = arglist.v.list[1].v.str;
 
-        fnum = number_func_by_name(fname);
-        if (fnum == FUNC_NOT_FOUND) {
+        const auto result = number_func_by_name(fname);
+        if (!result.has_value()) {
             p = make_raise_pack(E_INVARG, "Unknown built-in function",
                                 var_ref(arglist.v.list[1]));
             free_var(arglist);
         } else {
+            fnum = *result;
             arglist = listdelete(arglist, 1);
             p = call_bi_func(fnum, arglist, next, progr, vdata);
         }
@@ -3399,9 +3403,12 @@ bf_call_function_read(void)
 
     if (!strncmp(line, hdr, hlen)) {
         line += hlen;
-        if ((s->fnum = number_func_by_name(line)) == FUNC_NOT_FOUND)
+        const auto result = number_func_by_name(line);
+        if (!result.has_value())
             errlog("CALL_FUNCTION: Unknown built-in function: %s\n", line);
-        else if (read_bi_func_data(s->fnum, &s->data, pc_for_bi_func_data()))
+
+        s->fnum = *result;
+        if (read_bi_func_data(s->fnum, &s->data, pc_for_bi_func_data()))
             return s;
     }
     return nullptr;
@@ -3991,10 +3998,12 @@ read_activ(activation * a, int which_vector)
     }
     if (a->bi_func_pc != 0) {
         func_name = dbio_read_string();
-        if ((i = number_func_by_name(func_name)) == FUNC_NOT_FOUND) {
+        const auto result = number_func_by_name(func_name);
+        if (!result.has_value()) {
             errlog("READ_ACTIV: Unknown built-in function `%s'\n", func_name);
             return 0;
         }
+        i = *result;
         a->bi_func_id = i;
         if (!read_bi_func_data(a->bi_func_id, &a->bi_func_data,
                                &a->bi_func_pc)) {

--- a/src/include/functions.h
+++ b/src/include/functions.h
@@ -19,6 +19,7 @@
 #define Functions_h 1
 
 #include <stdio.h>
+#include <optional>
 
 #include "config.h"
 #include "execute.h"
@@ -76,10 +77,9 @@ typedef package(*bf_type) (Var, Byte, void *, Objid);
 typedef void (*bf_write_type) (void *vdata);
 typedef void *(*bf_read_type) (void);
 
-#define FUNC_NOT_FOUND   -1
-   
+  
 extern const char *name_func_by_num(unsigned);
-extern unsigned number_func_by_name(const char *);
+extern std::optional<unsigned> number_func_by_name(const char *);
 
 extern void register_function(const char *, int, int, bf_type,...);
 extern void register_function_with_read_write(const char *, int, int,

--- a/src/parser.y
+++ b/src/parser.y
@@ -25,6 +25,8 @@
 #include "my-math.h"
 #include <stdlib.h>
 #include <string.h>
+#include <functional>
+
 #include "ast.h"
 #include "code_gen.h"
 #include "config.h"
@@ -495,7 +497,8 @@ expr:
 		    unsigned f_no;
 
 		    $$ = alloc_expr(EXPR_CALL);
-		    if ((f_no = number_func_by_name($1)) == FUNC_NOT_FOUND) {
+const auto result = number_func_by_name($1);
+		    if (!result.has_value()) {
 			/* Replace with call_function("$1", @args) */
 			Expr           *fname = alloc_var(TYPE_STR);
 			Arg_List       *a = alloc_arg_list(ARG_NORMAL, fname);
@@ -503,9 +506,14 @@ expr:
 			fname->e.var.v.str = $1;
 			a->next = $3;
 			warning("Unknown built-in function: ", $1);
-			$$->e.call.func = number_func_by_name("call_function");
+/**
+* This could fail presumably, but there were no checks prior to this,
+* so I chose to leave it rather than try to abort and exclude code.
+*/
+			$$->e.call.func = *number_func_by_name("call_function");
 			$$->e.call.args = a;
 		    } else {
+						f_no = *result;
 			$$->e.call.func = f_no;
 			$$->e.call.args = $3;
 			dealloc_string($1);


### PR DESCRIPTION
problem:
Function lookups currently either by name or by ID are O(n). As we add more and more builtins with the limit lifting relatively soon, function calls and lookups will be slower. This also brings into issue an O(n) with multiple string comparisons.
solution: Update function name and ID lookups to use a hashtable. This makes lookups O(1) and also cuts back on multiple string comparisons.
This commit introduces a few fixes:
* Update to c++17 (for optional, also brings us extra move/copy ctor updates).
* Updated function lookups by name and by ID to use a hashtable.
* Updated retrieval of function ID by name to not return an arbitrary error. Instead, use Optional.
Risk:
Should be fairly minimal risk, but I would appreciate testing efforts from anyone else.
