### PR TITLE
add allowance for include_args and include_argstr

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -484,6 +484,13 @@
 /* #define INCLUDE_RT_VARS */
 
 /******************************************************************************
+* The server can include args and argstr in traceback stacks
+ ******************************************************************************
+*/
+/* #define INCLUDE_RT_ARGS */
+/* #define INCLUDE_RT_ARGSTR */
+
+/******************************************************************************
  * The server supports 64-bit integers. If you don't want the added memory usage
  * and don't need the larger integers, you can disable that here. NOTE: Disabling
  * this option and loading a database that has saved 64-bit integers will probably


### PR DESCRIPTION
Hello

So recently I found myself wanting the ability to include argstr and args as part of what handle_uncaught_error and such receive, without necessarily getting the whole (potentially very spammy) output given with include_rt_variables. This pr adds the ability to enable include_rt_args and include_rt_argstr.

I've structured this based on how I saw include_rt-vars done, but if I missed something I am sincerely sorry!

]Hoping this is okay :)