### PR TITLE
Seed the SOSEMANUK cipher from /dev/urandom

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -206,12 +206,6 @@ There are a few build options available to developers:
 
 To change the build, use: `cmake -D CMAKE_BUILD_TYPE:STRING=BuildNameHere ../`
 
-### Stuck seeding from /dev/random
-It can take some time to seed if your system is low on entropy. If you find startup hangs here, there are a couple of options:
-
-1. Install `haveged` to generate entropy.
-2. Edit `options.h` and change the value of MINIMUM_SEED_ENTROPY to something smaller, like 20.
-
 ### Login screen not showing
 Due to the way proxy detection works, if you're connecting to your MOO from localhost, you won't see the login screen. This is a minor inconvenience and shouldn't affect your ability to actually use your MOO. However, if it bothers you, you can disable HAProxy rewriting:
 

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -402,23 +402,6 @@
 #define FILE_IO_MAX_FILES     256
 
 /******************************************************************************
- * Minimum number of bytes of entropy (random data) to use to seed the
- * built-in pseudo-random number generator.  The server will read at
- * least this many bytes from /dev/random (or the configured source).
- * Since the source may block until sufficient entropy is available, a
- * large value (which is good for security) may delay startup.
- * Entropy is usually specified in bits, so multiply this value by
- * eight (8 bits) to get the minimum number of bits.  The default is
- * 20 bytes (160 bits).  Since the bytes are SHA256 hashed before
- * being used to seed a SOSEMANUK stream cypher running as a random
- * number generator, there is little value in setting this greater
- * than 32 bytes.
- ******************************************************************************
- */
-
-#define MINIMUM_SEED_ENTROPY 32
-
-/******************************************************************************
  * Enable log output colorization.
  ******************************************************************************
  */

--- a/src/include/version_opt_gen.pl
+++ b/src/include/version_opt_gen.pl
@@ -89,8 +89,6 @@ my @options =
    _DSTR => [qw(OUT_OF_BAND_PREFIX
 		OUT_OF_BAND_QUOTE_PREFIX
 	      )],
-   _DINT => [qw(MINIMUM_SEED_ENTROPY
-   		  )],
 
    # execution limits
    _DINT => [qw(DEFAULT_MAX_STACK_DEPTH

--- a/src/server.cc
+++ b/src/server.cc
@@ -83,7 +83,7 @@ extern "C" {
 #include "dependencies/linenoise.h"
 }
 
-#define RANDOM_DEVICE "/dev/random"
+#define RANDOM_DEVICE "/dev/urandom"
 
 static pid_t parent_pid;
 static bool in_child = false;
@@ -1272,15 +1272,9 @@ static void
 init_random(void)
 {
     long seed;
+    unsigned char soskey[32];
 
-    sha256_ctx context;
-    unsigned char input[32];
-    unsigned char output[32];
-
-    memset(input, 0, sizeof(input));
-    memset(output, 0, sizeof(output));
-
-    sha256_init(&context);
+    memset(soskey, 0, sizeof(soskey));
 
 #ifndef TEST
 
@@ -1294,19 +1288,14 @@ init_random(void)
     }
 
     ssize_t count = 0, total = 0;
-    ssize_t required = MIN(MINIMUM_SEED_ENTROPY, sizeof(input));
 
-    while (total < required) {
-        if (total)
-            oklog("RANDOM: seeding ... (more bytes required)\n");
-        if ((count = read(fd, input + total, sizeof(input) - total)) == -1) {
+    while (total < sizeof(soskey)) {
+        if ((count = read(fd, soskey + total, sizeof(soskey) - total)) == -1) {
             errlog("Can't read " RANDOM_DEVICE "!\n");
             exit(1);
         }
         total += count;
     }
-
-    sha256_update(&context, sizeof(input), input);
 
     close(fd);
 
@@ -1316,9 +1305,7 @@ init_random(void)
 
 #endif
 
-    sha256_digest(&context, sizeof(output), output);
-
-    sosemanuk_schedule(&key_context, output, sizeof(output));
+    sosemanuk_schedule(&key_context, soskey, sizeof(soskey));
 
     sosemanuk_init(&run_context, &key_context, nullptr, 0);
 


### PR DESCRIPTION
Hi, I was digging into blocking to read `/dev/random` to seed the SOSEMANUK cipher on startup, and `/dev/urandom` and `/dev/random`, and it seems to be unnecessary use `/dev/random` and block for a few reasons.

The SOSEMANUK cipher is only used in a single place in the codebase, in `bf_random_bytes()` in `src/numbers.cc`.
Since this is only used to expose the random_bytes function inside the MOO, and not for anything that needs cryptographic security, unless someone's implementing cryptographic functions *inside* of the database using it, using `/dev/random` is at best overkill.

Using `/dev/random` can block on server startup for a while, especially on an otherwise inactive server, and using `haveged` is more of a stopgap solution than a real fix.

Security-wise, the upstream Linux kernel developer consensus seems to be that the underlying CRNG behind `/dev/random` and `/dev/urandom` is good enough for cryptography, and that the blocking CRNG at best gives a misleading sense of how random the resulting data is [1], and isn't recommended for most uses, leading to `/dev/random` becoming like `/dev/urandom` in Linux versions later than 5.6 [2].
While it was once more widely recommended, current manpages for Linux describe `/dev/random` as "legacy interface which dates back to a time where the cryptographic primitives used in the implementation of `/dev/urandom` were not widely trusted" [3].
The only situation where `/dev/urandom` would return less secure data is during very early boot, before the entropy pool is initialized, and it exceedingly unlikely to be running toaststunt during early boot.

In addition, on modern FreeBSD [4] [5], OpenBSD [6], and MacOS [7], `/dev/random` and `/dev/urandom` are links to the same thing.

Due to this, we should save a lot of time on startup, without compromising security on reasonably modern systems, even if `random_bytes` were used in a cryptographic context in some databases.

I hope this isn't overly verbose, but I hope that it's helpful if someone with only a mild (outdated) understanding of `/dev/urandom` and `/dev/random` stumbles onto it (like me a few days ago, before I went down a rabbithole).
I apologize if I should add a note in the README that `haveged` shouldn't be necessary anymore, or that changing the `MINIMUM_SEED_ENTROPY` isn't needed anymore, or bump the `EXT` version number.
I instead removed the obsolete references without adding a note in the README because I wasn't sure on the guidelines for whether or not to do so.

[1] https://lwn.net/Articles/808575/
[2] https://github.com/torvalds/linux/commit/30c08efec8884fb106b8e57094baa51bb4c44e32
[3] https://man7.org/linux/man-pages/man4/random.4.html
[4] https://www.freebsd.org/cgi/man.cgi?query=random&apropos=0&sektion=4&manpath=FreeBSD+13.0-current&arch=default&format=html
[5] https://github.com/freebsd/freebsd-src/blob/b6be9566d236f83ad1a44170a64b9a34e382eafa/sys/dev/random/randomdev.c#L412
[6] https://man.openbsd.org/random.4
[7] https://www.unix.com/man-page/mojave/4/random