### PR TITLE
Add HTTP post functionality through Libcurl

### DIFF
--- a/src/curl.cc
+++ b/src/curl.cc
@@ -40,12 +40,16 @@ CurlWriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 
 void curl_thread_callback(Var arglist, Var *ret)
 {
+
+
+    CURL *curl_handle;
     CURLcode res;
     CurlMemoryStruct chunk;
 
     chunk.result = (char*)malloc(1);
     chunk.size = 0;
 
+    curl_handle = curl_easy_init();
     curl_easy_setopt(curl_handle, CURLOPT_URL, arglist.v.list[1].v.str);
     curl_easy_setopt(curl_handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, CurlWriteMemoryCallback);
@@ -76,7 +80,6 @@ bf_curl_get(Var arglist, Byte next, void *vdata, Objid progr)
         return make_error_pack(E_PERM);
     }
 
-    curl_handle = curl_easy_init();
     char *human_string = nullptr;
     asprintf(&human_string, "curl %s", arglist.v.list[1].v.str);
 
@@ -96,7 +99,6 @@ bf_curl_post(Var arglist, Byte next, void *vdata, Objid progr)
         return make_error_pack(E_PERM);
     }
 
-    curl_handle = curl_easy_init();
     char *human_string = nullptr;
     const char *data = arglist.v.list[2].v.str;
 

--- a/src/curl.cc
+++ b/src/curl.cc
@@ -12,10 +12,15 @@
 
 static CURL *curl_handle = nullptr;
 
+    static std::map<std::string, int>
+curl_option  = {{"post", 1}};
+
+
+
 typedef struct CurlMemoryStruct {
     char *result;
     size_t size;
-};
+} CurlMemoryStruct;
 
 static size_t
 CurlWriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
@@ -38,24 +43,54 @@ CurlWriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
     return realsize;
 }
 
-void curl_thread_callback(Var arglist, Var *ret)
+/* Initialize the curl handle with the indicated option */
+static void
+parse_curl_option(CURL *handle, Var arglist)
 {
 
+    const char *input = arglist.v.list[2].v.str;
 
-    CURL *curl_handle;
+    switch(curl_option[input])
+    {
+        case 1:
+        {
+            const char *data = arglist.v.list[3].v.str;
+            curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE, (long) strlen(data));
+            curl_easy_setopt(handle, CURLOPT_POSTFIELDS, data);
+            break;
+        }
+        default:
+            curl_easy_setopt(handle, CURLOPT_HTTPGET, 1L);
+
+    }
+
+}
+
+static void curl_thread_callback(Var arglist, Var *ret)
+{
+    int nargs = arglist.v.list[0].v.num;
     CURLcode res;
     CurlMemoryStruct chunk;
 
     chunk.result = (char*)malloc(1);
     chunk.size = 0;
 
-    curl_handle = curl_easy_init();
+    CURL *curl_handle = curl_easy_init();
     curl_easy_setopt(curl_handle, CURLOPT_URL, arglist.v.list[1].v.str);
     curl_easy_setopt(curl_handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, CurlWriteMemoryCallback);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
     curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
 
+    if (nargs >= 3) 
+    {
+
+        /* Set appropriate option */
+        parse_curl_option(curl_handle, arglist);
+
+        if (nargs == 4 && is_true(arglist.v.list[4]))
+            curl_easy_setopt(curl_handle, CURLOPT_HEADER, 1L);
+   }
 
     res = curl_easy_perform(curl_handle);
 
@@ -67,46 +102,16 @@ void curl_thread_callback(Var arglist, Var *ret)
     }
 
     curl_easy_cleanup(curl_handle);
-    free_var(arglist);
     free(chunk.result);
 }
 
 static package
-bf_curl_get(Var arglist, Byte next, void *vdata, Objid progr)
+bf_curl(Var arglist, Byte next, void *vdata, Objid progr)
 {
     if (!is_wizard(progr))
-    {
-        free_var(arglist);
         return make_error_pack(E_PERM);
-    }
 
     char *human_string = nullptr;
-    asprintf(&human_string, "curl %s", arglist.v.list[1].v.str);
-
-    if (arglist.v.list[0].v.num > 1 && is_true(arglist.v.list[2]))
-        curl_easy_setopt(curl_handle, CURLOPT_HEADER, 1L);
-
-    return background_thread(curl_thread_callback, &arglist, human_string);
-}
-
-
-static package
-bf_curl_post(Var arglist, Byte next, void *vdata, Objid progr)
-{
-    if (!is_wizard(progr))
-    {
-        free_var(arglist);
-        return make_error_pack(E_PERM);
-    }
-
-    char *human_string = nullptr;
-    const char *data = arglist.v.list[2].v.str;
-
-    if (arglist.v.list[0].v.num > 2 && is_true(arglist.v.list[3]))
-        curl_easy_setopt(curl_handle, CURLOPT_HEADER, 1L);
-
-    curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDSIZE, (long) strlen(data));
-    curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS, data);
     asprintf(&human_string, "curl %s", arglist.v.list[1].v.str);
 
     return background_thread(curl_thread_callback, &arglist, human_string);
@@ -170,9 +175,8 @@ register_curl(void)
     oklog("REGISTER_CURL: Using libcurl version %s\n", curl_version());
     curl_global_init(CURL_GLOBAL_ALL);
     curl_handle = curl_easy_init();
-
-    register_function("curl_get", 1, 2, bf_curl_get, TYPE_STR, TYPE_ANY);
-    register_function("curl_post", 2, 3, bf_curl_post, TYPE_STR, TYPE_STR, TYPE_ANY);
+ 
+   register_function("curl", 1, 4, bf_curl, TYPE_STR, TYPE_STR, TYPE_STR, TYPE_ANY);
     register_function("url_encode", 1, 1, bf_url_encode, TYPE_STR);
     register_function("url_decode", 1, 1, bf_url_decode, TYPE_STR);
 }


### PR DESCRIPTION
### *** COMPATIBILITY WARNINGS ***
  The following changes rename builtin function curl to curl_get. It accepts the same arguments and functionally executes the same way.


### curl_post
Syntax:   curl_post(STR *url*, STR *data*[, INT *include_headers*]) => STR  
The curl_post builtin will initiate an HTTP post request to the given url and return its response as a string. The curl_post function assumes data is a properly formatted json or xml string and does no further parsing. If <include_headers> is true, the HTTP headers will be included in the return string. The data you get back will be binary encoded.

Partially resolves #43