### PR TITLE
Added ceiling to ctime()

### DIFF
--- a/src/numbers.cc
+++ b/src/numbers.cc
@@ -631,7 +631,7 @@ bf_ctime(Var arglist, Byte next, void *vdata, Objid progr)
     const long int year_seconds = 31536000;
     Var r;
     time_t c;
-    char buffer[256];
+    char buffer[128];
     struct tm *t;
 
     if (arglist.v.list[0].v.num == 1) {

--- a/src/numbers.cc
+++ b/src/numbers.cc
@@ -629,13 +629,14 @@ static package
 bf_ctime(Var arglist, Byte next, void *vdata, Objid progr)
 {
     const long int year_seconds = 31536000;
+    const long int max_year = std::numeric_limits<int>::max() * year_seconds;
     Var r;
     time_t c;
     char buffer[128];
     struct tm *t;
 
     if (arglist.v.list[0].v.num == 1) {
-        c = std::min(arglist.v.list[1].v.num, std::numeric_limits<short>::max() * year_seconds);
+        c = std::min(arglist.v.list[1].v.num, max_year);
     } else {
         c = time(nullptr);
     }

--- a/src/numbers.cc
+++ b/src/numbers.cc
@@ -628,14 +628,17 @@ bf_time(Var arglist, Byte next, void *vdata, Objid progr)
 static package
 bf_ctime(Var arglist, Byte next, void *vdata, Objid progr)
 {
+    /* tm time structs have a max year equal to integer, which a 64 bit number of seconds will surpass */
     const long int year_seconds = 31536000;
     const long int max_year = std::numeric_limits<int>::max() * year_seconds;
+
     Var r;
     time_t c;
     char buffer[128];
     struct tm *t;
 
     if (arglist.v.list[0].v.num == 1) {
+        /* Make sure the year doesn't overflow */
         c = std::min(arglist.v.list[1].v.num, max_year);
     } else {
         c = time(nullptr);

--- a/src/numbers.cc
+++ b/src/numbers.cc
@@ -628,13 +628,14 @@ bf_time(Var arglist, Byte next, void *vdata, Objid progr)
 static package
 bf_ctime(Var arglist, Byte next, void *vdata, Objid progr)
 {
+    const long int year_seconds = 31536000;
     Var r;
     time_t c;
-    char buffer[128];
+    char buffer[256];
     struct tm *t;
 
     if (arglist.v.list[0].v.num == 1) {
-        c = arglist.v.list[1].v.num;
+        c = std::min(arglist.v.list[1].v.num, std::numeric_limits<short>::max() * year_seconds);
     } else {
         c = time(nullptr);
     }


### PR DESCRIPTION
This adds a ceiling to ctime that is reasonable to avoid hitting integer limits of tm_'s year variable. This prevents ctime($maxint) from throwing E_INVARG.