### PR TITLE
Add all_properties and tomap functions

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -484,6 +484,13 @@
 /* #define INCLUDE_RT_VARS */
 
 /******************************************************************************
+* The server can include args and argstr in traceback stacks
+ ******************************************************************************
+*/
+/* #define INCLUDE_RT_ARGS */
+/* #define INCLUDE_RT_ARGSTR */
+
+/******************************************************************************
  * The server supports 64-bit integers. If you don't want the added memory usage
  * and don't need the larger integers, you can disable that here. NOTE: Disabling
  * this option and loading a database that has saved 64-bit integers will probably


### PR DESCRIPTION
This PR adds:
all_properties >= returns a list of all the properties on n including ancestors.

tomap >= returns a datatype as a map, for waifs and objects, it freezes them  with keys as prop names and values as prop values.

I'd love someone with more experience than me to have a squint at the code in case I missed any memory problems.