### PR TITLE
Free waif self-reference on task_free

### DIFF
--- a/src/tasks.cc
+++ b/src/tasks.cc
@@ -610,6 +610,8 @@ free_task(task * t, int strong)
             if (strong) {
                 free_rt_env(t->t.forked.rt_env,
                             t->t.forked.program->num_var_names);
+                if(t->t.forked.a._this.type == TYPE_WAIF)
+                    free_var(t->t.forked.a._this);
                 free_str(t->t.forked.a.verb);
                 free_str(t->t.forked.a.verbname);
             }


### PR DESCRIPTION
The following code will create a hanging reference:

```
$waif::spawn_task   this none this
{?wait = 1} = args;
fork task_id (wait)
    player:tell("I'M A WAIF!");
endfork
kill_task(task_id);
 ```

The reference persists until shutdown:
```
;waif_stats()
=> ["pending_recycle" -> 0, "total" -> 0]
;$waif:new():spawn_task()
=> 0
;waif_stats()
=> [#118 -> 1, "pending_recycle" -> 0, "total" -> 1]
```

On shutdown, you will see the warning:
`WARN: waif_count != n_saved_waifs!`

This commit addresses the issue by freeing the reference created here in [tasks.cc:1273](https://github.com/lisdude/toaststunt/blob/master/src/tasks.cc#L1273).

