### PR TITLE
Add ability to initialize a blank DB via `_` input DB filename, fix help printing twice

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -1881,6 +1881,7 @@ print_usage()
     fprintf(stderr, "  %-20s %s\n", "-e, --emergency", "emergency wizard mode");
     fprintf(stderr, "  %-20s %s\n", "-l, --log", "redirect standard output to log file");
     fprintf(stderr, "\nDATABASE OPTIONS\n");
+    fprintf(stderr, "  %-20s %s\n", "_", "As a input-db-file, causes a new (completely blank) DB to be created.");
     fprintf(stderr, "  %-20s %s\n", "-m, --clear-move", "clear the `last_move' builtin property on all objects");
     fprintf(stderr, "  %-20s %s\n", "-w, --waif-type", "convert waifs from the specified type (check with typeof(waif) in your old MOO)");
     fprintf(stderr, "  %-20s %s\n", "-f, --start-script", "file to load and pass to `#0:do_start_script()'");
@@ -1902,6 +1903,7 @@ print_usage()
     fprintf(stderr, "Examples:\n");
     fprintf(stderr, "%s -c '$enable_debugging();' -f development.moo Minimal.db Minimal.db.new 7777\n", this_program);
     fprintf(stderr, "%s Minimal.db Minimal.db.new\n", this_program);
+    fprintf(stderr, "%s -e _ init.db\n", this_program);
 }
 
 int waif_conversion_type = _TYPE_WAIF;    /* For shame. We can remove this someday. */

--- a/src/server.cc
+++ b/src/server.cc
@@ -1973,7 +1973,7 @@ main(int argc, char **argv)
             case 'v':                   /* --version; print version and exit */
             {
                 fprintf(stderr, "ToastStunt version %s\n", server_version);
-                exit(1);
+                return 1;
             }
             break;
 
@@ -2016,7 +2016,7 @@ main(int argc, char **argv)
             {
 #ifndef OUTBOUND_NETWORK
                 fprintf(stderr, "Outbound networking is disabled. The '--outbound' option is invalid.\n");
-                exit(1);
+                return 1;
 #else
                 cmdline_outbound = true;
                 outbound_network_enabled = true;
@@ -2058,7 +2058,7 @@ main(int argc, char **argv)
             {
 #ifndef USE_TLS
                 fprintf(stderr, "TLS is disabled or not supported. The '--tls-port' option is invalid.\n");
-                exit(1);
+                return 1;
 #else
                 char *p = nullptr;
                 initial_tls_ports.push_back(strtoul(optarg, &p, 10));
@@ -2070,7 +2070,7 @@ main(int argc, char **argv)
             {
 #ifndef USE_TLS
                 fprintf(stderr, "TLS is disabled or not supported. The '--tls' option is invalid.\n");
-                exit(1);
+                return 1;
 #else
                 cmdline_cert = true;
                 default_certificate_path = optarg;
@@ -2082,7 +2082,7 @@ main(int argc, char **argv)
             {
 #ifndef USE_TLS
                 fprintf(stderr, "TLS is disabled or not supported. The '--tls' option is invalid.\n");
-                exit(1);
+                return 1;
 #else
                 cmdline_key = true;
                 default_key_path = optarg;
@@ -2106,11 +2106,10 @@ main(int argc, char **argv)
 
             case 'h':                   /* --help; show usage instructions */
                 print_usage();
-                break;
 
             default:
                 // Should we print usage here? It's pretty spammy...
-                exit(1);
+                return 1;
         }
     }
 
@@ -2124,7 +2123,7 @@ main(int argc, char **argv)
             set_log_file(f);
         else {
             perror("Error opening specified log file");
-            exit(1);
+            return 1;
         }
     } else {
         set_log_file(stderr);
@@ -2134,7 +2133,7 @@ main(int argc, char **argv)
             || !db_initialize(&argc, &argv)
             || !network_initialize(argc, argv, &desc)) {
         print_usage();
-        exit(1);
+        return 1;
     }
 
     if (initial_ports.empty()
@@ -2252,7 +2251,7 @@ main(int argc, char **argv)
 
     if (initial_listeners.size() < 1) {
         errlog("Can't create initial connection point!\n");
-        exit(1);
+        return 1;
     }
     free_var(desc);
     // I doubt anybody will have enough listeners for this to be worthwhile, but why not.
@@ -2264,7 +2263,7 @@ main(int argc, char **argv)
 #endif
 
     if (!db_load())
-        exit(1);
+        return 1;
 
     free_reordered_rt_env_values();
 
@@ -2305,7 +2304,7 @@ main(int argc, char **argv)
         }
 
         if (listen_failures >= initial_listeners.size())
-            exit(1);
+            return 1;
 
         initial_listeners.clear();
         initial_listeners.shrink_to_fit();


### PR DESCRIPTION
Helpful for someone who wants to start making their own DB just with the tools available from Emergency Wizard Mode.
For good measure, also changes how checkpointed connections are stored (so that it doesn't need a dedicated "initialize for new DB" function) to be a singly linked list that can simply be null-initialized.