### PR TITLE
Improve the PCRE cache

### DIFF
--- a/src/include/pcre_moo.h
+++ b/src/include/pcre_moo.h
@@ -18,7 +18,7 @@ struct pcre_cache_entry {
     pcre_extra *extra;
     int captures;
     unsigned int cache_hits;
-    unsigned int refcount;
+    std::atomic_uint refcount;
 };
 
 extern void pcre_shutdown(void);

--- a/src/include/pcre_moo.h
+++ b/src/include/pcre_moo.h
@@ -18,6 +18,7 @@ struct pcre_cache_entry {
     pcre_extra *extra;
     int captures;
     unsigned int cache_hits;
+    unsigned int refcount;
 };
 
 extern void pcre_shutdown(void);

--- a/src/pcre_moo.cc
+++ b/src/pcre_moo.cc
@@ -15,7 +15,6 @@
 #include "map.h"
 #include "dependencies/pcrs.h"
 #include "dependencies/xtrapbits.h"
-#undef PCRE_CONFIG_JIT
 
 struct StrCompare : public std::binary_function<const char*, const char*, bool>
 {
@@ -271,9 +270,7 @@ bf_pcre_match(Var arglist, Byte next, void *vdata, Objid progr)
 
 static void free_entry(pcre_cache_entry *entry)
 {
-    pthread_mutex_lock(&cache_mutex);
     if (--entry->refcount > 0) {
-        pthread_mutex_unlock(&cache_mutex);
         return;
     }
     if (entry->re != nullptr)
@@ -291,7 +288,6 @@ static void free_entry(pcre_cache_entry *entry)
     }
 
     free(entry);
-    pthread_mutex_unlock(&cache_mutex);
 }
 
 static void delete_cache_entry(const char *pattern)

--- a/src/pcre_moo.cc
+++ b/src/pcre_moo.cc
@@ -26,10 +26,11 @@ public:
 };
 
 static pthread_mutex_t cache_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP; // protect the cache
-static std::map<const char*, pcre_cache_entry*, StrCompare> pcre_pattern_cache;
+typedef std::pair<const char*, unsigned char> cache_type;
+static std::map<cache_type, pcre_cache_entry*> pcre_pattern_cache;
 
 static void free_entry(pcre_cache_entry *);
-static void delete_cache_entry(const char *pattern);
+static void delete_cache_entry(const char *pattern, unsigned char options);
 static Var result_indices(int ovector[], int n);
 
 static struct pcre_cache_entry *
@@ -38,14 +39,15 @@ get_pcre(const char *string, unsigned char options)
     pcre_cache_entry *entry = nullptr;
 
     pthread_mutex_lock(&cache_mutex);
-    if (pcre_pattern_cache.count(string) != 0) {
-        entry = pcre_pattern_cache[string];
+    cache_type pair = std::make_pair(string, options);
+    if (pcre_pattern_cache.count(pair) != 0) {
+        entry = pcre_pattern_cache[pair];
         entry->cache_hits++;
         entry->refcount++;
     } else {
         /* If the cache is too large, remove the entry with the least amount of hits. */
         if (pcre_pattern_cache.size() >= PCRE_PATTERN_CACHE_SIZE) {
-            std::map<const char*, pcre_cache_entry*, StrCompare>::iterator entry_to_delete = pcre_pattern_cache.begin(), it = entry_to_delete;
+            std::map<cache_type, pcre_cache_entry*>::iterator entry_to_delete = pcre_pattern_cache.begin(), it = entry_to_delete;
             while (it != pcre_pattern_cache.end()) {
                 if (it->second->cache_hits < entry_to_delete->second->cache_hits) {
                     entry_to_delete = it;
@@ -58,7 +60,7 @@ get_pcre(const char *string, unsigned char options)
             /* We could use delete_cache_entry here, and arguably it would be cleaner, but that would cause an extra pointless
                iteration full of string comparisons. Fortunately we have enough information here to deal with it directly. */
             free_entry(entry_to_delete->second);
-            free_str(entry_to_delete->first);
+            free_str(entry_to_delete->first.first);
             pcre_pattern_cache.erase(entry_to_delete);
         }
 
@@ -89,7 +91,7 @@ get_pcre(const char *string, unsigned char options)
 
         if (entry->error == nullptr) {
             entry->refcount++;
-            pcre_pattern_cache[str_dup(string)] = entry;
+            pcre_pattern_cache[std::make_pair(str_dup(string), options)] = entry;
         }
     }
 
@@ -165,7 +167,7 @@ bf_pcre_match(Var arglist, Byte next, void *vdata, Objid progr)
         if (rc < 0 && rc != PCRE_ERROR_NOMATCH)
         {
             /* We've encountered some funky error. Back out and let them know what it is. */
-            delete_cache_entry(pattern);
+            delete_cache_entry(pattern, options);
             free_entry(entry);
             free_var(arglist);
             sprintf(err, "pcre_exec returned error: %d", rc);
@@ -173,7 +175,7 @@ bf_pcre_match(Var arglist, Byte next, void *vdata, Objid progr)
         } else if (rc == 0) {
             /* We don't have enough room to store all of these substrings. */
             sprintf(err, "pcre_exec only has room for %d substrings", entry->captures);
-            delete_cache_entry(pattern);
+            delete_cache_entry(pattern, options);
             free_entry(entry);
             free_var(arglist);
             return make_raise_pack(E_QUOTA, err, var_ref(zero));
@@ -182,7 +184,7 @@ bf_pcre_match(Var arglist, Byte next, void *vdata, Objid progr)
             break;
         } else if (loops >= total_loops) {
             /* The loop has iterated beyond the maximum limit, probably locking the server. Kill it. */
-            delete_cache_entry(pattern);
+            delete_cache_entry(pattern, options);
             free_entry(entry);
             free_var(arglist);
             sprintf(err, "Too many iterations of matching loop: %u", loops);
@@ -290,11 +292,12 @@ static void free_entry(pcre_cache_entry *entry)
     free(entry);
 }
 
-static void delete_cache_entry(const char *pattern)
+static void delete_cache_entry(const char *pattern, unsigned char options)
 {
+    cache_type pair = std::make_pair(pattern, options);
     pthread_mutex_lock(&cache_mutex);
-    auto it = pcre_pattern_cache.find(pattern);
-    free_str(it->first);
+    auto it = pcre_pattern_cache.find(pair);
+    free_str(it->first.first);
     free_entry(it->second);
     pcre_pattern_cache.erase(it);
     pthread_mutex_unlock(&cache_mutex);
@@ -375,7 +378,7 @@ bf_pcre_cache_stats(Var arglist, Byte next, void *vdata, Objid progr)
     for (const auto& x : pcre_pattern_cache) {
         count++;
         Var entry = new_list(2);
-        entry.v.list[1] = str_dup_to_var(x.first);
+        entry.v.list[1] = str_dup_to_var(x.first.first);
         entry.v.list[2] = Var::new_int(x.second->cache_hits);
         ret.v.list[count] = entry;
     }
@@ -388,7 +391,7 @@ pcre_shutdown(void)
 {
     for (const auto& x : pcre_pattern_cache) {
         free_entry(x.second);
-        free_str(x.first);
+        free_str(x.first.first);
     }
 
     pcre_pattern_cache.clear();


### PR DESCRIPTION
This fixes the following problems with the cache:
1. It would crash the server if it was used from multiple threads.
2. The case matters option to pcre_match wasn't being taken into account, and the cache would match the wrong pattern. Example:
```
;pcre_match("test", "e", 0)
=> {["0" -> ["match" -> "e", "position" -> {2, 2}]]}
;pcre_match("TEST", "e", 1)
=> {["0" -> ["match" -> "E", "position" -> {2, 2}]]}
```

With this PR applied:
```
;pcre_match("test", "e", 0)
=> {["0" -> ["match" -> "e", "position" -> {2, 2}]]}
;pcre_match("TEST", "e", 1)
=> {}
```
