### PR TITLE
Fix PCRE cache

### DIFF
--- a/src/include/pcre_moo.h
+++ b/src/include/pcre_moo.h
@@ -20,6 +20,7 @@ struct pcre_cache_entry {
     unsigned int cache_hits;
     std::atomic_uint refcount;
 };
+typedef std::pair<const char*, unsigned char> cache_type;
 
 extern void pcre_shutdown(void);
 

--- a/src/pcre_moo.cc
+++ b/src/pcre_moo.cc
@@ -3,7 +3,7 @@
 #ifdef PCRE_FOUND
 
 #include <ctype.h>
-#include <map>
+#include <unordered_map>
 #include <limits.h>
 
 #include "pcre_moo.h"
@@ -16,18 +16,27 @@
 #include "dependencies/pcrs.h"
 #include "dependencies/xtrapbits.h"
 
-struct StrCompare : public std::binary_function<const char*, const char*, bool>
+template<>
+struct std::hash<cache_type>
+{
+    std::size_t operator()(const cache_type& t) const noexcept
+    {
+        return std::hash<std::string>{}(std::string(t.first) + (char)t.second);
+    }
+};
+
+struct CacheEqual : public std::binary_function<const cache_type&, const cache_type&, bool>
 {
 public:
-    bool operator() (const char* str1, const char* str2) const
+    bool operator() (const cache_type& c1, const cache_type& c2) const
     {
-        return strcmp(str1, str2) < 0;
+        return strcmp(c1.first, c2.first) == 0 && c1.second == c2.second;
     }
 };
 
 static pthread_mutex_t cache_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP; // protect the cache
 typedef std::pair<const char*, unsigned char> cache_type;
-static std::map<cache_type, pcre_cache_entry*> pcre_pattern_cache;
+static std::unordered_map<cache_type, pcre_cache_entry*, std::hash<cache_type>, CacheEqual> pcre_pattern_cache;
 
 static void free_entry(pcre_cache_entry *);
 static void delete_cache_entry(const char *pattern, unsigned char options);
@@ -47,7 +56,7 @@ get_pcre(const char *string, unsigned char options)
     } else {
         /* If the cache is too large, remove the entry with the least amount of hits. */
         if (pcre_pattern_cache.size() >= PCRE_PATTERN_CACHE_SIZE) {
-            std::map<cache_type, pcre_cache_entry*>::iterator entry_to_delete = pcre_pattern_cache.begin(), it = entry_to_delete;
+            std::unordered_map<cache_type, pcre_cache_entry*, std::hash<cache_type>, CacheEqual>::iterator entry_to_delete = pcre_pattern_cache.begin(), it = entry_to_delete;
             while (it != pcre_pattern_cache.end()) {
                 if (it->second->cache_hits < entry_to_delete->second->cache_hits) {
                     entry_to_delete = it;
@@ -59,9 +68,10 @@ get_pcre(const char *string, unsigned char options)
             }
             /* We could use delete_cache_entry here, and arguably it would be cleaner, but that would cause an extra pointless
                iteration full of string comparisons. Fortunately we have enough information here to deal with it directly. */
-            free_entry(entry_to_delete->second);
-            free_str(entry_to_delete->first.first);
+            auto entry = *entry_to_delete;
             pcre_pattern_cache.erase(entry_to_delete);
+            free_entry(entry.second);
+            free_str(entry.first.first);
         }
 
         const char *err;
@@ -82,7 +92,7 @@ get_pcre(const char *string, unsigned char options)
             entry->error = str_dup(buf);
         } else {
             const char *error = nullptr;
-//            entry->extra = pcre_study(entry->re, 0, &error);
+            entry->extra = pcre_study(entry->re, 0, &error);
             if (error != nullptr)
                 entry->error = str_dup(error);
             else
@@ -297,9 +307,10 @@ static void delete_cache_entry(const char *pattern, unsigned char options)
     cache_type pair = std::make_pair(pattern, options);
     pthread_mutex_lock(&cache_mutex);
     auto it = pcre_pattern_cache.find(pair);
-    free_str(it->first.first);
-    free_entry(it->second);
+    auto entry = *it;
     pcre_pattern_cache.erase(it);
+    free_str(entry.first.first);
+    free_entry(entry.second);
     pthread_mutex_unlock(&cache_mutex);
 }
 


### PR DESCRIPTION
The cache now uses an unordered_map with a custom hash function,
because you can't usefully compare an std::pair<const char*, unsigned char>.
The JIT has also been re-enabled.
