### PR TITLE
Fixed preprocessor 'if' being reversed

### DIFF
--- a/src/curl.cc
+++ b/src/curl.cc
@@ -1,6 +1,6 @@
 #include "options.h"
 
-#ifdef CURL_FOUND
+#ifndef CURL_FOUND
 
 #include <curl/curl.h>
 


### PR DESCRIPTION
The first #ifdef CURL_FOUND was opposite of what it should be given the context of the code, and it was not compiling properly because CURL_FOUND was being redefined or not defined.

Changing this to #ifndef CURL_FOUND fixed the issue in my testing. Tested with a new ToastCore db.